### PR TITLE
Update readme, add --help option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Screenshot script with QR Scanner feature (Forked from [u/LithiumFrost](https://
 <h2><span style="color:red">!! BETA VERSION !!</span></h2>
 this is beta version, something is (maybe) broken and unstable and questionable
 
-this is for test purpose, please be carefull
+this is for test purpose, please be careful
 
 ---
 ### Name Meaning
@@ -16,7 +16,7 @@ It should be noted that the cursor isn't included in screenshots.
 
 #### milestones
 * added user config support (already merged to main)
-* added wayland support (big thanks to [WTechNinja](https://github.com/WTechNinja) ([jump to his repo](https://github.com/WTechNinja/eses/tree/eses-w)) ( the wayland support are belongs to WTechNinja )
+* added wayland support (big thanks to [WTechNinja](https://github.com/WTechNinja) ([jump to his repo](https://github.com/WTechNinja/eses/tree/eses-w)) ( the wayland support belongs to WTechNinja )
 
 ### Function
 * --whole
@@ -36,34 +36,34 @@ It should be noted that the cursor isn't included in screenshots.
 All of the default configuration is in the beginning of the eses script with plenty of comments, and it will likely change. As of writing this, the default config is:
 
 ```
-# Notification title when maim --hidecursor successfully saved
+# Notification title when a screenshot is saved to disk, or copied to clipboard
 succ_noTit="Kasha!"
 
-# Notification text when maim --hidecursor successfully saved
+# Notification text when a screenshot is captured, and saved to disk
 succ_noTex="Screenshot saved!"
 
-# Notification text when maim --hidecursor successfully saved
+# Notification text when a screenshot is captured, and copied to clipboard
 succ_noTex_cp="Screenshot copied to clipboard!"
 
-# Notification title when QR Scanned and copied
+# Notification title when a QR Code is scanned and copied to clipboard
 succ_noTit_sccop="QR Code scan result"
 
 # Prompt dialog title when qr code scanned
 dia_tit="Prompt"
 
 # Prompt dialog text when qr code scanned
-dia_tex="QR Code detected, and sucessfully scanned\n Do you want to copy the scan result instead?"
+dia_tex="QR Code detected, and sucessfully scanned.\n Do you want to copy the scan result instead?"
 
 # Prompt dialog copy image button
 dia_imgcop_butt="Copy image"
 
-# Prompt dialog copy image button
+# Prompt dialog copy scan result button
 dia_sccop_butt="Copy scan result"
 
-# maim --hidecursor save dir
+# Screenshot save dir
 sv_dir="/home/$USER/Pictures/"
 
-# maim --hidecursor file name
+# Screenshot file name
 sv_name="$(date)"
 ```
 

--- a/eses-beta
+++ b/eses-beta
@@ -60,65 +60,86 @@ sv_name="$(date)"
 		whatDis=1;
 	fi
 
-	# it will be 0 if wayland and 1 if X11
-
-	# for test purpose, will delete later
-	echo $whatDis
-	
+	# it will be 0 if wayland and 1 if X11	
 
 ## Code
 
+function printHelp {
+printf 'Usage: eses-beta [OPTION]
+Screenshot script with QR Scanner feature
+	 
+There are four modes, selectable by the below options:
+  --select        Screenshot selected area / selected window, and save it as a file
+  --whole         Screenshot whole screen and save it as a file in your desired folder
+  --whole_cp      Screenshot whole screen and put it on clipboard without saving
+  --select_cp     Screenshot selected area / selected window, and put it on clipboard, then run QR code magic.
+
+    Also try looking at "man eses" for more documentation.
+'
+}
+
+
 if [ $whatDis = "0" ]; then
 	case "$1" in
+		--help)
+			printHelp
+			echo "    eses is currently running in Wayland mode."
+			;;
 		--select)
-  			grim -g "$(slurp)" "$sv_dir$sv_name"
-  			notify-send -t 1000 "$succ_noTit" "$succ_noTex"
-  			;;
- 		--whole)
-  			grim "$sv_dir$sv_name"
-  			notify-send -t 1000 "$succ_noTit" "$succ_noTex"
-  			;;
- 		--whole_cp)
-  			grim - | wl-copy -t image/png
-  			notify-send -t 1000 "$succ_noTit" "$succ_noTex_cp"
-  			;;
- 		--select_cp)
-  			tmp_file="/tmp/qr.png"
+			grim -g "$(slurp)" "$sv_dir$sv_name"
+			notify-send -a eses "$succ_noTit" "$succ_noTex"
+			;;
+		--whole)
+			grim "$sv_dir$sv_name"
+			notify-send -a eses "$succ_noTit" "$succ_noTex"
+			;;
+		--whole_cp)
+			grim - | wl-copy -t image/png
+			notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
+			;;
+		--select_cp)
+			tmp_file="/tmp/qr.png"
 
-  			# maimselect > "$tmp_file"
-  			grim -g "$(slurp)" "$tmp_file"
-  			scanresult=$(zbarimg --quiet --raw "$tmp_file" | tr -d '\n')
+			# maimselect > "$tmp_file"
+			grim -g "$(slurp)" "$tmp_file"
+			scanresult=$(zbarimg --quiet --raw "$tmp_file" | tr -d '\n')
 
-  			if [ -z "$scanresult" ]; then
-   				wl-copy -t image/png < $tmp_file
-   				notify-send "$succ_noTit" "$succ_noTex_cp"
-  			else
-   				ask=$(zenity --question --text="$dia_tex" --title="$dia_tit" --icon-name=info --no-wrap --ok-label="$dia_sccop_butt" --cancel-label="$dia_imgcop_butt" --ellipsize)
-   				if [ $? = "0" ]; then
-    					echo "$scanresult" | wl-copy
-    					convert $tmp_file -resize 75x75 "$tmp_file"
-    					notify-send -i "$tmp_file" "$succ_noTit_sccop" "$scanresult"
-   				elif [ $? = "1" ]; then
-    					wl-copy -t image/png < $tmp_file
-    					notify-send -t 1000 "$succ_noTit" "$succ_noTex_cp"
-   				fi
-  			fi
-  			;;
+			if [ -z "$scanresult" ]; then
+				wl-copy -t image/png < $tmp_file
+				notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
+			else
+				ask=$(zenity --question --text="$dia_tex" --title="$dia_tit" --icon-name=info \
+				--no-wrap --ok-label="$dia_sccop_butt" --cancel-label="$dia_imgcop_butt" --ellipsize)
+
+				if [ $? = "0" ]; then
+						echo "$scanresult" | wl-copy
+						convert $tmp_file -resize 75x75 "$tmp_file"
+						notify-send -a eses -i "$tmp_file" "$succ_noTit_sccop" "$scanresult"
+				elif [ $? = "1" ]; then
+						wl-copy -t image/png < $tmp_file
+						notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
+				fi
+			fi
+			;;
 	esac
 
 elif [ $whatDis = "1" ]; then
 	case "$1" in
+		--help)
+			printHelp
+			echo '    eses is currently running in Xorg (x11) mode.'
+			;;
 		--select)
 			maim --hidecursor --select "$sv_dir$sv_name"
-			notify-send "$succ_noTit" "$succ_noTex"
+			notify-send -a eses "$succ_noTit" "$succ_noTex"
 			;;
 		--whole)
 			maim --hidecursor "$sv_dir$sv_name"
-			notify-send "$succ_noTit" "$succ_noTex"
+			notify-send -a eses "$succ_noTit" "$succ_noTex"
 			;;
 		--whole_cp)
 			maim --hidecursor | xclip -selection clipboard -t image/png
-			notify-send "$succ_noTit" "$succ_noTex_cp"
+			notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
 			;;
 		--select_cp)
 			tmp_file="/tmp/qr.png"
@@ -129,16 +150,16 @@ elif [ $whatDis = "1" ]; then
 
 			if [ -z "$scanresult" ]; then
 				xclip -selection clipboard -t image/png $tmp_file
-				notify-send "$succ_noTit" "$succ_noTex_cp"
+				notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
 			else
 				ask=$(zenity --question --text="$dia_tex" --title="$dia_tit" --icon-name=info --no-wrap --ok-label="$dia_sccop_butt" --cancel-label="$dia_imgcop_butt" --ellipsize)
 				if [ $? = "0" ]; then
 					echo "$scanresult" | xclip -selection clipboard -filter
 					convert $tmp_file -resize 75x75 "$tmp_file"
-					notify-send -i "$tmp_file" "$succ_noTit_sccop" "$scanresult"
+					notify-send -a eses -i "$tmp_file" "$succ_noTit_sccop" "$scanresult"
 				elif [ $? = "1" ]; then
 					xclip -selection clipboard -t image/png $tmp_file
-					notify-send "$succ_noTit" "$succ_noTex_cp"
+					notify-send -a eses "$succ_noTit" "$succ_noTex_cp"
 				fi
 			fi
 			;;

--- a/eses-beta
+++ b/eses-beta
@@ -1,35 +1,35 @@
 #!/bin/bash
 
-## Configuration, will be overrided by config file
+## Configuration, will be overridden by config file
 	
-# Notification title when maim --hidecursor successfully saved
+# Notification title when a screenshot is saved to disk, or copied to clipboard
 succ_noTit="Kasha!"
 
-# Notification text when maim --hidecursor successfully saved
+# Notification text when a screenshot is captured, and saved to disk
 succ_noTex="Screenshot saved!"
 
-# Notification text when maim --hidecursor successfully saved
+# Notification text when a screenshot is captured, and copied to clipboard
 succ_noTex_cp="Screenshot copied to clipboard!"
 
-# Notification title when QR Scanned and copied
+# Notification title when a QR Code is scanned and copied to clipboard
 succ_noTit_sccop="QR Code scan result"
 
 # Prompt dialog title when qr code scanned
 dia_tit="Prompt"
 
 # Prompt dialog text when qr code scanned
-dia_tex="QR Code detected, and sucessfully scanned\n Do you want to copy the scan result instead?"
+dia_tex="QR Code detected, and sucessfully scanned.\n Do you want to copy the scan result instead?"
 
 # Prompt dialog copy image button
 dia_imgcop_butt="Copy image"
 
-# Prompt dialog copy image button
+# Prompt dialog copy scan result button
 dia_sccop_butt="Copy scan result"
 
-# maim --hidecursor save dir
+# Screenshot save dir
 sv_dir="/home/$USER/Pictures/"
 
-# maim --hidecursor file name
+# Screenshot file name
 sv_name="$(date)"
 
 ## Overriding Config file (will auto make them)

--- a/man/eses.1.md
+++ b/man/eses.1.md
@@ -1,31 +1,31 @@
 % ESES(1) eses 
-% WTechNinja
+% WTechNinja, kaonkaon
 % April 2022
 
 # NAME
-eses - Screenshot scripts with QR Scanner feature
+eses - Screenshot script with QR Scanner feature
 
 # SYNOPSIS
 **eses** [OPTION]
 
 	
 # DESCRIPTION
-Basic screenshot script with QR Scanner feature (yes i wrote this twice). Good for making a keybind for screenshots (you can use another decent apps/scripts, really)
+Basic screenshot script with QR Scanner feature. Good for screenshot keybindings. It should be noted that the cursor isn't included in screenshots.
 In the **--select-cp** mode, if there's a QR Code detected in the picture, it will try to scan it. If it fails, it will leave the screenshot copied on the clipboard, if it succeeds it will prompt to ask if you want the QR Code result on your clipboard.
 Has four different modes, selectable via options.
 
 # OPTIONS
 **--whole**
-: Screenshot whole screen (without cursor) and save it as a file in your desired folders (set it yourself by changing the scripts)
+: Screenshot whole screen and save it as a file in your desired folder (set it yourself by changing the config)
 
 **--select**
 : Screenshot selected area / selected window, and save it as a file
 
 **--whole_cp**
-: Screenshot whole screen (without cursor) and put it on clipboard without saving (save your precious Kb in your HDD/SSD)
+: Screenshot whole screen and put it on clipboard without saving (save the precious Kb on your HDD/SSD)
 
 **--select_cp**
-: Screenshot selected area / selected window, and put it on clipboard, then run QR code magic. 
+: Screenshot selected area / selected window, and put it on clipboard, then run QR code magic. If a QR Code is detected in the screenshot, it will try to scan it. If it fails, it will leave the screenshot on the clipboard, but if it succeeds you will be prompted to copy either the image or the scanned result.
 
 # EXAMPLES
 **eses --select_cp**


### PR DESCRIPTION
So, I was testing the beta branch and it all works on my system, so if it's working on yours as well we can merge it into main.
But also, I have this pull request to add to it

Stuff changed: 

- added more details to the readme
- added --help option with basic usage, also has a message at the bottom saying if you're running in wayland or x11 mode, and then removed the "echo $whatDis" line from `eses-beta`.
- replaced the spaces in the indented areas with tabs, which wasn't necessary but I did it anyway
- Also, added `-a eses` to all of the `notify-send` lines, because that way if anyone wants to have custom rules for eses notifications they can, and also if we ever have an icon (unlikely, but you never know) it should show up on notifications. 
- I also removed the `-t 1000` lines from the wayland `notify-send` commands, because it makes the notifications show up for only one second and I only added it for my laptop's sake. (I like these notifications to only show up for a moment)

Please test it out, I've been testing it myself and it all looks good but it'd be nice to have a second opinion